### PR TITLE
添加cookie缓存相关功能, 优化了签到的逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /libs/info2.py
 /libs/__pycache__/
 /logs/
+cookie_cache

--- a/README.md
+++ b/README.md
@@ -39,11 +39,24 @@
 3. 修改 `libs\info.py`文件，填上自己的学号、密码以及要预约的座位号
 
 4. 运行 `reserve.py`即可预约，运行 `sign.py`可签到
+   - 预约: 
    ~~~shell
    python reserve.py
    ~~~
+   #
+   - 签到info.py中的所有人:
    ~~~shell
    python sign.py
+   ~~~
+   - 签到info.py中指定的几个人, 
+   昵称后随冒号及其cookie(可选)表示指定该签到者的ic-cookie, 从而跳过登录
+   ~~~shell
+   python sign.py 猪猪侠 皮卡丘:cookie
+   ~~~
+   - 签到并缓存登录的ic-cookie, 使得下次签到时跳过登录, cookie过期也会自动更新.
+   这需要运行环境可以创建和更改文件, 云函数, Github Actions一般不满足
+   ~~~shell
+   python sign.py 猪猪侠 皮卡丘 -c [缓存路径和文件名, 默认为cookie_cache]
    ~~~
 
 <br/>

--- a/libs/source.py
+++ b/libs/source.py
@@ -1,23 +1,117 @@
-import json
 import re
 import sys
+import json
 import typing
-from datetime import datetime, timedelta, timezone
+
 from pathlib import Path
 from urllib.parse import unquote
+from enum import Enum, auto, unique
+from datetime import datetime, timedelta, timezone
 
 import httpx
-from loguru import logger
 from lxml import etree
+from loguru import logger
 
 from .rsa import RSA  # 外部文件
 
+# 初始化logger
+# 如果 logs 文件夹不存在则创建
+logDir = Path(__file__).parent.parent / 'logs'
+if logDir.exists() is False:
+    logDir.mkdir()
+
+# 日志文件用 年-月-日 命名
+logFile = Path(logDir / f'{datetime.now().year}-{datetime.now().month}-{datetime.now().day}.log')
+
+# 日志打印、保存。 保存位置、打印格式、颜色、4天清理一次日志
+logger.configure(handlers=[
+    {
+        'sink': sys.stderr,
+        'format': '<lvl>{time:YYYY-MM-DD HH:mm:ss.SSS}</> <lvl>|</> <lvl>{message}</>',
+        'colorize': True
+    },
+    {
+        'sink': logFile,
+        'format': '<lvl>{time:YYYY-MM-DD HH:mm:ss.SSS}</> <lvl>|</> <lvl>{message}</>',
+        'colorize': False,
+        'retention': '4 days'
+    },
+])
+
+@unique
+class ReturnCode(Enum):
+    SUCCESS = auto()
+    ALREADY_SIGNED = auto()
+    # ALREADY_RESERVED = auto()
+    NO_RESERVATION = auto()
+    GET_LOGIN_URL_FAILED = auto()
+    LOGIN_SKIPED = auto()
+    COOKIE_EXPIRED = auto()
+    FAILED = auto()
+
+    def __str__(self):
+        match self:
+            case ReturnCode.SUCCESS:
+                return "成功"
+            case ReturnCode.ALREADY_SIGNED:
+                return "重复签到"
+            # case ReturnCode.ALREADY_RESERVED:
+            #     return "已预约"
+            case ReturnCode.NO_RESERVATION:
+                return "没有预约"
+            case ReturnCode.GET_LOGIN_URL_FAILED:
+                return "获取登录url失败"
+            case ReturnCode.LOGIN_SKIPED:
+                return "跳过登录"
+            case ReturnCode.COOKIE_EXPIRED:
+                return "cookie过期"
+            case ReturnCode.FAILED:
+                return "失败"
+            case _:
+                return "未知错误"
+            
+def load_cookie_cache(path: str) -> dict:
+    """
+    从缓存文件中加载cookie
+    :param cookie_path: cookie缓存文件路径
+    :return: cookie字典
+    """
+    
+    if Path(path).exists():
+        # ic-cookie is a uuid
+        uuid_pattern = re.compile(r'[a-f\d]{8}-(?:[a-f\d]{4}-){3}[a-f\d]{12}')
+    
+        with open(path, 'r', encoding='utf-8') as f:
+            cookies = f.readlines()
+            cookie_dict = dict()
+            for line in cookies:
+                line = line.strip().split(None, 1)
+                if len(line) != 2:
+                    logger.warning(f'{line[0]} 的cookie为空')
+                    continue
+                if not re.fullmatch(uuid_pattern, line[1]):
+                    logger.warning(f'{line[0]}: {line[1]} 不是合法的cookie')
+                    continue
+
+                # cookie_dict[name] = ic_cookie
+                cookie_dict[line[0]] = line[1]
+
+        return cookie_dict
+    else:
+        logger.warning(f'cookie缓存文件不存在, 路径: {path}')
+        return dict()
+
+def save_cookie_cache(path: str, cookies: dict):
+    with open(path, 'w+', encoding='utf-8') as f:
+        for name, cookie in cookies.items():
+            f.write(f'{name} {cookie}\n')
+    logger.info(f'cookie缓存文件已保存到 {path}')
 
 class ZWYT(object):
-    def __init__(self, name, username, password, periods, pushplus_token):
+    def __init__(self, name, username, password, periods, pushplus_token, *, cookie = ''):
         self.resvDev = None  # 座位编号
         self.roomId = None
-        self.cookies = {'ic-cookie': ''}  # 保存登录用的 cookie
+        self.cookies = {'ic-cookie': cookie}  # 保存登录用的 cookie
         self.name = name  # 名字
         self.username = str(username)  # 学号
         self.password = str(password)  # 密码
@@ -26,13 +120,37 @@ class ZWYT(object):
 
         # url接口
         self.urls = {
-            'login_url': '',  # 登录
-            'reserve': 'http://libbooking.gzhu.edu.cn/ic-web/reserve',  # 预约
-            'seatmenu': 'http://libbooking.gzhu.edu.cn/ic-web/seatMenu',  # 获取 roomId
+            # 登录
+            'login_url': '',  
+            # 预约
+            'reserve': 'http://libbooking.gzhu.edu.cn/ic-web/reserve',  
+            # 获取 roomId
+            'seatmenu': 'http://libbooking.gzhu.edu.cn/ic-web/seatMenu',  
             'findaddress': 'http://libbooking.gzhu.edu.cn/ic-web/auth/address',
             'get_location': 'http://libbooking.gzhu.edu.cn/authcenter/toLoginPage',
-            'userinfo': 'http://libbooking.gzhu.edu.cn/ic-web/auth/userInfo',  # 获取用户信息
-            'pushplus': 'http://www.pushplus.plus/send'  # pushplus
+            # 获取用户信息
+            'userinfo': 'http://libbooking.gzhu.edu.cn/ic-web/auth/userInfo',  
+
+            # 获取预约信息
+            'resvinfo': 'https://libbooking.gzhu.edu.cn/ic-web/reserve/resvInfo?beginDate={date:%Y-%m-%d}&endDate={date:%Y-%m-%d}&needStatus={needStatus}',
+            # request url:
+            # https://libbooking.gzhu.edu.cn/ic-web/reserve/resvInfo?
+            #   * beginDate=2025-02-17& // 查询开始日期 (必填)
+            #   * endDate=2025-02-23&   // 查询结束日期 (必填)
+            #   * needStatus=6&         // 查询预约的状态 (非必填), 为并集查询: 如6 = 2 + 4 则查询待生效和已生效的预约
+            #       1预约成功 2待生效 4已生效 16已违约 64已签到 128已结束 256待审核 512审核未通过 1024审核通过 2048已暂离 8192待同意 16384举报
+            #   (非必填)
+            #   * page=1&               // 页号
+            #   * pageNum=10&           // 页大小
+            #   * orderKey=gmt_create&  // 排序相关?
+            #   * orderModel=desc       // 排序相关?
+
+            # 结束正在进行的预约(api确实是endAhaed, 乐)
+            'end_ahead': 'https://libbooking.gzhu.edu.cn/ic-web/reserve/endAhaed', 
+            # 删除预约
+            'delete': 'https://libbooking.gzhu.edu.cn/ic-web/reserve/delete',
+            # pushplus
+            'pushplus': 'http://www.pushplus.plus/send'
         }
 
         # xpath 匹配规则
@@ -55,28 +173,7 @@ class ZWYT(object):
         # 初始化请求连接对象
         self.rr = httpx.Client()
 
-        # 如果 logs 文件夹不存在则创建
-        logDir = Path(__file__).parent.parent / 'logs'
-        if logDir.exists() is False:
-            logDir.mkdir()
 
-        # 日志文件用 年-月-日 命名
-        logFile = Path(logDir / f'{datetime.now().year}-{datetime.now().month}-{datetime.now().day}.log')
-
-        # 日志打印、保存。 保存位置、打印格式、颜色、4天清理一次日志
-        logger.configure(handlers=[
-            {
-                'sink': sys.stderr,
-                'format': '<lvl>{time:YYYY-MM-DD HH:mm:ss.SSS}</> <lvl>|</> <lvl>{message}</>',
-                'colorize': True
-            },
-            {
-                'sink': logFile,
-                'format': '<lvl>{time:YYYY-MM-DD HH:mm:ss.SSS}</> <lvl>|</> <lvl>{message}</>',
-                'colorize': False,
-                'retention': '4 days'
-            },
-        ])
 
     # pushplus 推送消息到微信
     def pushplus(self, title, content):
@@ -176,12 +273,19 @@ class ZWYT(object):
        ...
 
     # 登录
-    def login(self):
+    def login(self, force_login: bool = False) -> ReturnCode:
         """
         登录
         """
-        if self.cookies['ic-cookie']:
-            return
+        if not force_login and self.cookies['ic-cookie']:
+            logger.info('ic-cookie已存在, 跳过登录')
+            return ReturnCode.LOGIN_SKIPED
+        
+        try: 
+            self.get_login_url()
+        except Exception as e:
+            logger.error(f'获取登录url失败: {e}')
+            return ReturnCode.GET_LOGIN_URL_FAILED
 
         res = self.rr.get(url=self.urls['login_url'], timeout=60)  # 请求登录url获取一些参数
         html = etree.HTML(res.text)
@@ -232,6 +336,8 @@ class ZWYT(object):
         icc = get_cookie_res.headers.get('Set-Cookie')
         self.cookies['ic-cookie'] = re.findall('ic-cookie=(.*?);', icc)[0]
 
+        return ReturnCode.SUCCESS
+
     #  获取登录url
     def get_login_url(self):
         """
@@ -271,22 +377,87 @@ class ZWYT(object):
         n_year, n_month, n_day = next_day.year, next_day.month, next_day.day
 
         # 要返回的数据
-        reserve_days = []
+        reserve_todays = []
+        reserve_tomorrows = []
 
         # 添加起始和结束时间
         for period in self.periods:
-            reserve_days.extend([
+            reserve_todays.append(
                 {
                     'start': f"{c_year}-{c_month}-{c_day} {period[0]}",  # 今天--起始时间
                     'end': f"{c_year}-{c_month}-{c_day} {period[-1]}"  # 今天--结束时间
-                },
+                }
+            )
+            reserve_tomorrows.append(
                 {
                     'start': f"{n_year}-{n_month}-{n_day} {period[0]}",  # 明天--起始时间
                     'end': f"{n_year}-{n_month}-{n_day} {period[-1]}"  # 明天--结束时间
-                }
-            ])
+                },
+            )
 
-        return reserve_days
+        return reserve_tomorrows + reserve_todays
+    
+    # 查询正在进行并需要签到的预约
+    def get_ahead_reservation(self):
+        utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)  # UTC 时间
+        SHA_TZ = timezone(timedelta(hours=8), name='Asia/Shanghai', )  # 上海市区, 也就是东八区，比 UTC 快 8 个小时
+        current_day = utc_now.astimezone(SHA_TZ)  # 今天的日期： 北京时间
+
+        # 4: 已生效的预约
+        needStatus = 4
+        logger.info(f'查询正在进行的预约, 当前日期: {current_day:%Y-%m-%d}')
+        url = self.urls['resvinfo'].format(date=current_day, needStatus=4)
+        # logger.info(f'查询url: {url}')
+
+        res = self.rr.get(
+            url=url, 
+            cookies=self.cookies, 
+            timeout=15
+        ) # 4: 已生效的预约
+        res = res.json()
+        resv = []
+        
+        code = res.get('code')
+        match code:
+            case 0:
+                for item in res.get('data'):
+                    resvStatus = item.get('resvStatus')
+                    # 判断是否已签到: 
+                    # 不必判断: 1预约成功, 1024审核通过
+                    
+                    # (not 64已签到 || 2048已暂离)
+                    if (resvStatus & 64 == 0) or (resvStatus & 2048 != 0):
+                        resv.append(item)
+            case 300:
+                # ic-cookie 已失效, 需要重新登录
+                logger.warning(f'{self.name}的ic-cookie已失效, 需要重新登录')
+                return None, ReturnCode.COOKIE_EXPIRED
+            case _:
+                logger.error(f'查询失败: {res.get("message")}, 状态码: {code}')
+                return None, ReturnCode.FAILED
+
+
+        logger.info(f'查询到{self.name}的预约项: {len(resv)}(未预约)/{res.get("count")}(已生效)')
+        if len(resv) == 0:
+            logger.info(f'{self.name} 没有查询到需要签到的预约')
+            return None, ReturnCode.NO_RESERVATION
+        elif len(resv) > 1:
+            logger.warning(f'{self.name} 查询到了多个正在进行的预约: {resv}')
+
+        return resv[0], ReturnCode.SUCCESS
+
+    def sign_for_ahead_reservation(self) -> ReturnCode:
+        """
+        为正在进行的预约签到
+        """
+
+        resv, errc = self.get_ahead_reservation()
+
+        if errc != ReturnCode.SUCCESS:
+            return errc
+        
+        devName = resv.get('resvDevInfoList')[0].get('devName')
+        return self.sign(devName)
 
     # 预约
     def reserve(self, devName: str):
@@ -295,10 +466,6 @@ class ZWYT(object):
         """
         # 获取所预约的座位编号
         self.resvDev = self.get_seat_resvDev_devSn(devName, 'reserve')
-
-        # 登录
-        self.get_login_url()
-        self.login()
 
         # 获取用户的 appAccNo
         appAccNo = self.get_person_appAccNo()
@@ -341,12 +508,10 @@ class ZWYT(object):
                 logger.error(f"{self.name} 时间段: {json_data['resvBeginTime']} 预约失败 {message}")
 
     # 签到
-    def sign(self, devName: str):
+    def sign(self, devName: str) -> ReturnCode:
         """
         签到
         """
-        self.get_login_url()
-        self.login()
 
         lurl = "http://libbooking.gzhu.edu.cn/ic-web/phoneSeatReserve/login"
         url = "http://libbooking.gzhu.edu.cn/ic-web/phoneSeatReserve/sign"
@@ -370,12 +535,11 @@ class ZWYT(object):
             devName = re.findall("-(.*)处", res1_data.get('message'))[0]
 
             # 调用签到函数进行签到，传入预约座位号
-            self.sign(devName)
-            return
+            return self.sign(devName)
 
         # 暂无预约
         if res1_data.get('data').get('reserveInfo') is None:
-            return
+            return ReturnCode.NO_RESERVATION
 
         # 获取预约编号
         resvId = res1_data.get('data').get('reserveInfo').get('resvId')
@@ -390,11 +554,14 @@ class ZWYT(object):
         # 签到成功
         if message == '操作成功':
             logger.success(f"{self.name} 签到成功--{message}")
+            return ReturnCode.SUCCESS
 
         # 已经签到过
         elif message == '用户已签到，请勿重复签到':
             logger.warning(f'{self.name} {message}')
+            return ReturnCode.ALREADY_SIGNED
 
         # 签到失败
         else:
             logger.error(f"{self.name}--签到失败--{message}")
+            return ReturnCode.FAILED

--- a/reserve.py
+++ b/reserve.py
@@ -13,6 +13,7 @@ def main(*args, **kwargs):
             yy = ZWYT(stu['name'], stu['sno'], stu['pwd'], stu['periods'], stu['pushplus'])
 
             # 调用预约函数预约，传入预约座位号
+            yy.login(force_login = True)
             yy.reserve(stu['devName'])
         except Exception as e:
             print(e)

--- a/sign.py
+++ b/sign.py
@@ -79,9 +79,6 @@ def main():
                 if retc in (ReturnCode.SUCCESS, ReturnCode.ALREADY_SIGNED, ReturnCode.NO_RESERVATION):
                     break
 
-                # elif retc in (ReturnCode.COOKIE_EXPIRED, ReturnCode.FAILED):
-                #     continue
- 
 
         except Exception as e:
             print(e)

--- a/sign.py
+++ b/sign.py
@@ -1,25 +1,96 @@
 """
 签到
 """
+
+import argparse
+
 from libs.info import infos
-from libs.source import ZWYT
+from libs.source import ZWYT, ReturnCode, load_cookie_cache, save_cookie_cache
 
 
-def main(*args, **kwargs):
-    # 遍历 info 信息，获取每个用户的昵称、预约座位号、用户名、密码、时间段、推送token（推送可以为空）
-    for stu in infos:
+def main():
+
+    parser = argparse.ArgumentParser(
+        prog = 'sign.py',
+        description = 'GZHU图书馆签到脚本',
+    )
+    
+    # 指定需要签到的用户昵称及其cookie对, 格式为name:cookie
+    # 不指定则默认签到info中的所有用户, 另外cookie项可忽略. 
+    # 例如：python sign.py 猪猪侠:cookie1 皮卡丘:cookie2 熊猫
+    parser.add_argument('name_cookie_pairs', nargs = '*')
+
+    # 指定使用缓存ic-cookie的文件, 不指定则不使用cookie缓存, 
+    # 缓存cookie的文件名默认为cookie_cache
+    # 脚本优先使用命令行中提供的cookie, 没有提供则使用缓存的cookie文件
+    # 如果命令行没有提供cookie, 也没有缓存的cookie文件, 或者cookie错误或过期, 则尝试直接登录
+    parser.add_argument('-c', '--cookie', nargs = '?', const = 'cookie_cache', default = None, required = False)
+
+    args = parser.parse_args()
+
+    target_infos = []
+    
+    if args.name_cookie_pairs:
+        targets = dict()
+        for pair in args.name_cookie_pairs:
+            pair = pair.split(':', 1)
+            targets[pair[0]] = pair[1] if len(pair) == 2 else None  
+
+        for stu in infos:
+            name = stu['name']
+            if name in targets:
+                # cookie is appointed by command line
+                if targets[name] is not None:
+                    stu['cookie'] = targets[name]
+                target_infos.append(stu)
+    else:
+        target_infos = infos
+
+    cookie_dirty = False
+    external_cookies = {}
+    if args.cookie is not None:
+        external_cookies = load_cookie_cache(args.cookie)
+
+    # 遍历 target_infos 信息，获取每个用户的昵称、预约座位号、用户名、密码、时间段、推送token（推送可以为空）
+    for stu in target_infos:
+        name = stu['name']
+        cookie = stu.get('cookie', external_cookies.get(name, ''))
         try:
             # 初初始化类示例，传入昵称、用户名、密码、时间段、推送token（推送可以为空）
-            yy = ZWYT(stu['name'], stu['sno'], stu['pwd'], stu['periods'], stu['pushplus'])
+            yy = ZWYT(name, stu['sno'], stu['pwd'], stu['periods'], stu['pushplus'], cookie = cookie)
 
-            # 调用签到函数进行签到，传入预约座位号
-            yy.sign(stu['devName'])
+
+            # 尝试签到的次数, 不应该少于2次, 因为如果cookie过期则会导致签到失败, 需要重新登录
+            retc = ReturnCode.SUCCESS
+            for _ in range(2):
+                # 登录, 如果cookie已存在则会跳过
+                retc = yy.login(force_login = retc == ReturnCode.COOKIE_EXPIRED)
+                if retc == ReturnCode.SUCCESS: 
+                    # 更新cookie
+                    external_cookies[name] = yy.cookies['ic-cookie']
+                    cookie_dirty = True
+                elif retc == ReturnCode.GET_LOGIN_URL_FAILED:
+                    if stu['pushplus']:
+                        yy.pushplus(f"{name} {stu['devName']} 登录失败", "获取登录链接失败")
+                    break
+
+                # 签到
+                retc = yy.sign_for_ahead_reservation()
+                if retc in (ReturnCode.SUCCESS, ReturnCode.ALREADY_SIGNED, ReturnCode.NO_RESERVATION):
+                    break
+
+                # elif retc in (ReturnCode.COOKIE_EXPIRED, ReturnCode.FAILED):
+                #     continue
+ 
+
         except Exception as e:
             print(e)
             if stu['pushplus']:
-                yy.pushplus(f"{stu['name']} {stu['devName']} 签到失败", e)
+                yy.pushplus(f"{name} {stu['devName']} 签到失败", e)
             continue
-
+    
+    if args.cookie and cookie_dirty:
+        save_cookie_cache(args.cookie, external_cookies)
 
 if __name__ == '__main__':
-    main()
+    exit(main())


### PR DESCRIPTION
主要在签到逻辑上做了些更改.
1. 给sign.py添加了命令行参数, 详见更新后的readme.
* 主要的作用是使签到时可以复用登录的ic-cookie. 就我的目测, 只要每次向服务器发送请求(比如查询, 签到等动作)间隔不超过30分钟, ic-cookie就可以无限续杯, 一整天都可以复用当天第一次登录的cookie而不用再登录. 不登录的好处是避免偶尔获取登录url失败, 从而签到失败的问题. 另外reserve.py暂时还没有写复用cookie的逻辑. 
* 由于缓存cookie需要读写文件, 因此云函数, Github Actions等部署环境可能不能使用该功能. 但是Github Actions似乎也有缓存和读写变量之类的设施, 可以配合命令行直接传入cookie使用.
* 原本签到的使用方法没有改变, 应该可以正常使用的.
2. sign.py现在会先查询当前是否有可以签到的预约, 有的话再对查询得到的座位进行签到, 否则什么都不做. 这样的行为逻辑更加正常且不可疑一点. 笑;
3. 为了判断每个动作的返回结果, 简单搞了个返回码ReturnCode的Enum, 目前暂时还没想到更好的解决方案;
4. 剩下的就是稍微统一了一下logger的风格, 将logger的初始化提到ZWYT类的外面进行, 调整预约项的顺序, 另外添加了几个url接口但是暂时还没有使用.

另外是不是得在readme里提醒一下大家不要直接fork一份就在fork的公开仓库里写info信息然后直接运行..? 点进fork的仓库里一看学号姓名密码什么的直接暴露了都😢